### PR TITLE
Add settings menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ HAVE_APPLICATION_FLAG_GLOBAL_PIN = 1
 HAVE_APPLICATION_FLAG_BOLOS_SETTINGS = 1
 HAVE_APPLICATION_FLAG_LIBRARY = 1
 
+# Enables direct data signing without having to specify it in the settings.
+ALLOW_DATA?=0
+ifneq ($(ALLOW_DATA),0)
+DEFINES += HAVE_ALLOW_DATA
+endif
+
 ifeq ($(COIN),qtum_testnet)
 
 # Qtum testnet, no legacy support

--- a/src/common/script.c
+++ b/src/common/script.c
@@ -15,7 +15,6 @@
 #include "../crypto.h"
 #endif
 
-#ifndef SKIP_FOR_CMOCKA
 #define DELEGATIONS_ADDRESS    "\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x86"
 #define ADD_DELEGATION_HASH    "\x4c\x0e\x96\x8c"
 #define REMOVE_DELEGATION_HASH "\x3d\x66\x6e\x8b"
@@ -413,6 +412,7 @@ bool get_sender_sig(uint8_t *buffer, size_t size, uint8_t **sig, unsigned int *s
            *sigSize > 0;
 }
 
+#ifndef SKIP_FOR_CMOCKA
 bool opcall_addr_encode(const uint8_t script[],
                         size_t script_len,
                         char *out,

--- a/src/common/script.c
+++ b/src/common/script.c
@@ -379,6 +379,10 @@ bool is_opsender(const uint8_t script[], size_t script_len) {
     return is_opcontract((uint8_t *) script, script_len, OP_SENDER);
 }
 
+bool is_contract(const uint8_t script[], size_t script_len) {
+    return is_opcreate(script, script_len) || is_opcall(script, script_len);
+}
+
 bool get_script_sender_address(uint8_t *buffer, size_t size, uint8_t *script) {
     uint8_t *pkh = 0;
     unsigned int pkhSize = 0;

--- a/src/common/script.h
+++ b/src/common/script.h
@@ -182,6 +182,8 @@ bool is_opcall(const uint8_t script[], size_t script_len);
 
 bool is_opsender(const uint8_t script[], size_t script_len);
 
+bool is_contract(const uint8_t script[], size_t script_len);
+
 /**
  * Returns the size in bytes of the minimal push opcode for <n>, where n a uint32_t.
  */

--- a/src/common/script.h
+++ b/src/common/script.h
@@ -182,7 +182,7 @@ bool is_opcall(const uint8_t script[], size_t script_len);
 
 bool is_opsender(const uint8_t script[], size_t script_len);
 
-bool is_contract(const uint8_t script[], size_t script_len);
+bool is_contract_blind_sign(const uint8_t script[], size_t script_len);
 
 /**
  * Returns the size in bytes of the minimal push opcode for <n>, where n a uint32_t.

--- a/src/constants.h
+++ b/src/constants.h
@@ -33,7 +33,7 @@
  * Maximum scriptPubKey length for an output that we can recognize.
  */
 #define MAX_OUTPUT_SCRIPTPUBKEY_LEN 400  // max 393 for contracts; other scripts are shorter
-#define MAX_INPUT_SCRIPTPUBKEY_LEN  35  // P2PK's scriptPubKeys are the longest supported
+#define MAX_INPUT_SCRIPTPUBKEY_LEN  35   // P2PK's scriptPubKeys are the longest supported
 
 /**
  * Maximum length of a wallet registered into the device (characters), excluding terminating NULL.

--- a/src/constants.h
+++ b/src/constants.h
@@ -33,7 +33,7 @@
  * Maximum scriptPubKey length for an output that we can recognize.
  */
 #define MAX_OUTPUT_SCRIPTPUBKEY_LEN 400  // max 393 for contracts; other scripts are shorter
-#define MAX_INPUT_SCRIPTPUBKEY_LEN  83   // max 83 for OP_RETURN; other scripts are shorter
+#define MAX_INPUT_SCRIPTPUBKEY_LEN  35  // P2PK's scriptPubKeys are the longest supported
 
 /**
  * Maximum length of a wallet registered into the device (characters), excluding terminating NULL.

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "ux.h"
 
@@ -27,3 +28,14 @@ extern ux_state_t G_ux;
  * Global structure with the parameters to exchange with the BOLOS UX application.
  */
 extern bolos_ux_params_t G_ux_params;
+
+#define N_storage (*(volatile internalStorage_t *) PIC(&N_storage_real))
+typedef struct internalStorage_t {
+    bool dataAllowed;
+    bool initialized;
+} internalStorage_t;
+
+/**
+ * Global structure for settings storage.
+ */
+extern const internalStorage_t N_storage_real;

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1370,7 +1370,6 @@ static bool read_outputs(dispatcher_context_t *dc,
         output_info_t output;
         memset(&output, 0, sizeof(output));
         bool isOpSender = false;
-        bool isContract = false;
 
         output_keys_callback_data_t callback_data = {.output = &output,
                                                      .placeholder_info = placeholder_info};
@@ -1440,11 +1439,13 @@ static bool read_outputs(dispatcher_context_t *dc,
             ++external_outputs_count;
 
             // check if output contract data is allowed
-            isContract = is_contract(output.in_out.scriptPubKey, output.in_out.scriptPubKey_len);
-            if(isContract && !N_storage.dataAllowed) {
+            bool isContractBlindSign = is_contract_blind_sign(output.in_out.scriptPubKey, output.in_out.scriptPubKey_len);
+            if(isContractBlindSign && !N_storage.dataAllowed) {
                 ui_warn_contract_data(dc);
-                SEND_SW(dc, SW_SIGNATURE_FAIL);
-                return false;
+                if(!N_storage.dataAllowed) {
+                    SEND_SW(dc, SW_SIGNATURE_FAIL);
+                    return false;
+                }
             }
 
             if (!dry_run &&

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1370,6 +1370,7 @@ static bool read_outputs(dispatcher_context_t *dc,
         output_info_t output;
         memset(&output, 0, sizeof(output));
         bool isOpSender = false;
+        bool isContract = false;
 
         output_keys_callback_data_t callback_data = {.output = &output,
                                                      .placeholder_info = placeholder_info};
@@ -1437,6 +1438,14 @@ static bool read_outputs(dispatcher_context_t *dc,
         } else if (is_internal == 0) {
             // external output, user needs to validate
             ++external_outputs_count;
+
+            // check if output contract data is allowed
+            isContract = is_contract(output.in_out.scriptPubKey, output.in_out.scriptPubKey_len);
+            if(isContract && !N_storage.dataAllowed) {
+                ui_warn_contract_data(dc);
+                SEND_SW(dc, SW_SIGNATURE_FAIL);
+                return false;
+            }
 
             if (!dry_run &&
                 !display_output(dc, st, cur_output_index, external_outputs_count, &output))

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1439,10 +1439,11 @@ static bool read_outputs(dispatcher_context_t *dc,
             ++external_outputs_count;
 
             // check if output contract data is allowed
-            bool isContractBlindSign = is_contract_blind_sign(output.in_out.scriptPubKey, output.in_out.scriptPubKey_len);
-            if(isContractBlindSign && !N_storage.dataAllowed) {
+            bool isContractBlindSign =
+                is_contract_blind_sign(output.in_out.scriptPubKey, output.in_out.scriptPubKey_len);
+            if (isContractBlindSign && !N_storage.dataAllowed) {
                 ui_warn_contract_data(dc);
-                if(!N_storage.dataAllowed) {
+                if (!N_storage.dataAllowed) {
                     SEND_SW(dc, SW_SIGNATURE_FAIL);
                     return false;
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,8 @@ bolos_ux_params_t G_ux_params;
 
 dispatcher_context_t G_dispatcher_context;
 
+const internalStorage_t N_storage_real;
+
 // clang-format off
 const command_descriptor_t COMMAND_DESCRIPTORS[] = {
     {
@@ -236,6 +238,17 @@ void coin_main() {
                 G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
 #endif  // HAVE_BLE
 
+                if (!N_storage.initialized) {
+                    internalStorage_t storage;
+#ifdef HAVE_ALLOW_DATA
+                    storage.dataAllowed = true;
+#else
+                    storage.dataAllowed = false;
+#endif
+                    storage.initialized = true;
+                    nvm_write((void *) &N_storage, (void *) &storage, sizeof(internalStorage_t));
+                }
+
                 USB_power(0);
                 USB_power(1);
 
@@ -288,6 +301,17 @@ static void swap_library_main_helper(struct libargs_s *args) {
                 UX_INIT();
                 ux_stack_push();
 #endif  // HAVE_BAGL
+
+                if (!N_storage.initialized) {
+                    internalStorage_t storage;
+#ifdef HAVE_ALLOW_DATA
+                    storage.dataAllowed = true;
+#else
+                    storage.dataAllowed = false;
+#endif
+                    storage.initialized = true;
+                    nvm_write((void *) &N_storage, (void *) &storage, sizeof(internalStorage_t));
+                }
 
                 USB_power(0);
                 USB_power(1);

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -172,6 +172,11 @@ bool ui_warn_nondefault_sighash(dispatcher_context_t *context) {
     return io_ui_process(context, true);
 }
 
+bool ui_warn_contract_data(dispatcher_context_t *context) {
+    ui_warning_contract_data();
+    return io_ui_process(context, true);
+}
+
 bool ui_transaction_prompt(dispatcher_context_t *context,
                            const int external_outputs_total_count,
                            const bool sign_sender) {

--- a/src/ui/display.h
+++ b/src/ui/display.h
@@ -126,6 +126,8 @@ bool ui_warn_unverified_segwit_inputs(dispatcher_context_t *context);
 
 bool ui_warn_nondefault_sighash(dispatcher_context_t *context);
 
+bool ui_warn_contract_data(dispatcher_context_t *context);
+
 bool ui_validate_output(dispatcher_context_t *context,
                         int index,
                         int total_count,
@@ -178,6 +180,8 @@ bool ui_post_processing_confirm_wallet_spend(dispatcher_context_t *context, bool
 bool ui_post_processing_confirm_transaction(dispatcher_context_t *context, bool success);
 
 bool ui_post_processing_confirm_message(dispatcher_context_t *context, bool success);
+
+void ui_warning_contract_data(void);
 
 #ifdef HAVE_NBGL
 bool ui_transaction_prompt(dispatcher_context_t *context,

--- a/src/ui/display_bagl.c
+++ b/src/ui/display_bagl.c
@@ -247,6 +247,27 @@ UX_STEP_CB(ux_sign_message_accept_new,
            set_ux_flow_response(true),
            {&C_icon_validate_14, "Sign", "message"});
 
+#ifdef TARGET_NANOS
+UX_STEP_CB(
+    ux_warning_contract_data_step,
+    bnnn_paging,
+    set_ux_flow_response(false),
+    {
+      "Error",
+      "Blind signing must be enabled in Settings",
+    });
+#else
+UX_STEP_CB(
+    ux_warning_contract_data_step,
+    pnn,
+    set_ux_flow_response(false),
+    {
+      &C_icon_crossmark,
+      "Blind signing must be",
+      "enabled in Settings",
+    });
+#endif
+
 // FLOW to display BIP32 path and a message hash to sign:
 // #1 screen: certificate icon + "Sign message"
 // #2 screen: display BIP32 Path
@@ -424,6 +445,8 @@ UX_FLOW(ux_sign_sender_transaction_flow,
         &ux_sign_sender_step,
         &ux_display_reject_step);
 
+UX_FLOW(ux_warning_contract_data_flow, &ux_warning_contract_data_step);
+
 void ui_display_pubkey_flow(void) {
     ux_flow_init(0, ux_display_pubkey_flow, NULL);
 }
@@ -490,6 +513,10 @@ void ui_accept_transaction_flow(bool is_self_transfer, bool sign_sender) {
                      is_self_transfer ? ux_accept_selftransfer_flow : ux_accept_transaction_flow,
                      NULL);
     }
+}
+
+void ui_warning_contract_data(void) {
+    ux_flow_init(0, ux_warning_contract_data_flow, NULL);
 }
 
 #endif  // HAVE_BAGL

--- a/src/ui/display_bagl.c
+++ b/src/ui/display_bagl.c
@@ -248,24 +248,22 @@ UX_STEP_CB(ux_sign_message_accept_new,
            {&C_icon_validate_14, "Sign", "message"});
 
 #ifdef TARGET_NANOS
-UX_STEP_CB(
-    ux_warning_contract_data_step,
-    bnnn_paging,
-    set_ux_flow_response(false),
-    {
-      "Error",
-      "Blind signing must be enabled in Settings",
-    });
+UX_STEP_CB(ux_warning_contract_data_step,
+           bnnn_paging,
+           set_ux_flow_response(false),
+           {
+               "Error",
+               "Blind signing must be enabled in Settings",
+           });
 #else
-UX_STEP_CB(
-    ux_warning_contract_data_step,
-    pnn,
-    set_ux_flow_response(false),
-    {
-      &C_icon_crossmark,
-      "Blind signing must be",
-      "enabled in Settings",
-    });
+UX_STEP_CB(ux_warning_contract_data_step,
+           pnn,
+           set_ux_flow_response(false),
+           {
+               &C_icon_crossmark,
+               "Blind signing must be",
+               "enabled in Settings",
+           });
 #endif
 
 // FLOW to display BIP32 path and a message hash to sign:

--- a/src/ui/display_nbgl.c
+++ b/src/ui/display_nbgl.c
@@ -549,4 +549,21 @@ void ui_display_post_processing_confirm_wallet_spend(bool success) {
     }
 }
 
+static void ui_warning_contract_data_choice(bool confirm) {
+    if (confirm) {
+        ux_flow_response_false();
+    } else {
+        ui_menu_settings();
+    }
+}
+
+void ui_warning_contract_data(void) {
+    nbgl_useCaseChoice(&C_round_warning_64px,
+                       "This message cannot\nbe clear-signed",
+                       "Enable blind-signing in\nthe settings to sign\nthis transaction.",
+                       "Exit",
+                       "Go to settings",
+                       ui_warning_contract_data_choice);
+}
+
 #endif  // HAVE_NBGL

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -19,3 +19,8 @@ void ui_menu_main_flow_bitcoin(void);
  * Show main menu for Testnet (ready screen, version, about, quit).
  */
 void ui_menu_main_flow_bitcoin_testnet(void);
+
+/**
+ * Show settings submenu
+ */
+void ui_menu_settings(void);

--- a/src/ui/menu_bagl.c
+++ b/src/ui/menu_bagl.c
@@ -34,7 +34,7 @@ UX_STEP_NOCB(ux_menu_ready_step_bitcoin_testnet,
 
 UX_STEP_NOCB(ux_menu_version_step, bn, {"Version", APPVERSION});
 UX_STEP_CB(ux_menu_about_step, pb, ui_menu_about(), {&C_icon_certificate, "About"});
-UX_STEP_CB(ux_menu_settings_step, pb, ui_menu_settings(), {&C_icon_eye,"Settings"});
+UX_STEP_CB(ux_menu_settings_step, pb, ui_menu_settings(), {&C_icon_eye, "Settings"});
 UX_STEP_VALID(ux_menu_exit_step, pb, os_sched_exit(-1), {&C_icon_dashboard_x, "Quit"});
 
 // FLOW for the main menu (for bitcoin):
@@ -99,8 +99,8 @@ void ui_menu_settings(void) {
 #define DISABLED_STR  "Disabled"
 #define BUF_INCREMENT (MAX(strlen(ENABLED_STR), strlen(DISABLED_STR)) + 1)
 char strings[BUF_INCREMENT];
-#define SETTING_BLIND_SIGNING_STATE       strings
-#define BOOL_TO_STATE_STR(b) (b ? ENABLED_STR : DISABLED_STR)
+#define SETTING_BLIND_SIGNING_STATE strings
+#define BOOL_TO_STATE_STR(b)        (b ? ENABLED_STR : DISABLED_STR)
 
 // clang-format off
 UX_STEP_CB(

--- a/src/ui/menu_bagl.c
+++ b/src/ui/menu_bagl.c
@@ -34,7 +34,7 @@ UX_STEP_NOCB(ux_menu_ready_step_bitcoin_testnet,
 
 UX_STEP_NOCB(ux_menu_version_step, bn, {"Version", APPVERSION});
 UX_STEP_CB(ux_menu_about_step, pb, ui_menu_about(), {&C_icon_certificate, "About"});
-UX_STEP_CB(ux_menu_settings_step, pb, display_settings(NULL), {&C_icon_eye,"Settings"});
+UX_STEP_CB(ux_menu_settings_step, pb, ui_menu_settings(), {&C_icon_eye,"Settings"});
 UX_STEP_VALID(ux_menu_exit_step, pb, os_sched_exit(-1), {&C_icon_dashboard_x, "Quit"});
 
 // FLOW for the main menu (for bitcoin):
@@ -89,6 +89,10 @@ void ui_menu_main_flow_bitcoin_testnet(void) {
 
 void ui_menu_about(void) {
     ux_flow_init(0, ux_menu_about_flow, NULL);
+}
+
+void ui_menu_settings(void) {
+    display_settings(NULL);
 }
 
 #define ENABLED_STR   "Enabled"

--- a/src/ui/menu_bagl.c
+++ b/src/ui/menu_bagl.c
@@ -137,4 +137,5 @@ static void toggle_setting(volatile bool* setting, const ux_flow_step_t* ui_step
 static void switch_settings_blind_signing(void) {
     toggle_setting(&N_storage.dataAllowed, &ux_settings_flow_blind_signing_step);
 }
+
 #endif  // HAVE_BAGL

--- a/src/ui/menu_bagl.c
+++ b/src/ui/menu_bagl.c
@@ -22,6 +22,9 @@
 #include "../globals.h"
 #include "menu.h"
 
+static void display_settings(const ux_flow_step_t* const start_step);
+static void switch_settings_blind_signing(void);
+
 // We have a screen with the icon and "Bitcoin is ready" for Bitcoin,
 // "Bitcoin Testnet is ready" for Bitcoin Testnet.
 UX_STEP_NOCB(ux_menu_ready_step_bitcoin, pnn, {&C_bitcoin_logo, "Qtum", "is ready"});
@@ -31,6 +34,7 @@ UX_STEP_NOCB(ux_menu_ready_step_bitcoin_testnet,
 
 UX_STEP_NOCB(ux_menu_version_step, bn, {"Version", APPVERSION});
 UX_STEP_CB(ux_menu_about_step, pb, ui_menu_about(), {&C_icon_certificate, "About"});
+UX_STEP_CB(ux_menu_settings_step, pb, display_settings(NULL), {&C_icon_eye,"Settings"});
 UX_STEP_VALID(ux_menu_exit_step, pb, os_sched_exit(-1), {&C_icon_dashboard_x, "Quit"});
 
 // FLOW for the main menu (for bitcoin):
@@ -42,6 +46,7 @@ UX_FLOW(ux_menu_main_flow_bitcoin,
         &ux_menu_ready_step_bitcoin,
         &ux_menu_version_step,
         &ux_menu_about_step,
+        &ux_menu_settings_step,
         &ux_menu_exit_step,
         FLOW_LOOP);
 
@@ -54,6 +59,7 @@ UX_FLOW(ux_menu_main_flow_bitcoin_testnet,
         &ux_menu_ready_step_bitcoin_testnet,
         &ux_menu_version_step,
         &ux_menu_about_step,
+        &ux_menu_settings_step,
         &ux_menu_exit_step,
         FLOW_LOOP);
 
@@ -83,5 +89,52 @@ void ui_menu_main_flow_bitcoin_testnet(void) {
 
 void ui_menu_about(void) {
     ux_flow_init(0, ux_menu_about_flow, NULL);
+}
+
+#define ENABLED_STR   "Enabled"
+#define DISABLED_STR  "Disabled"
+#define BUF_INCREMENT (MAX(strlen(ENABLED_STR), strlen(DISABLED_STR)) + 1)
+char strings[BUF_INCREMENT];
+#define SETTING_BLIND_SIGNING_STATE       strings
+#define BOOL_TO_STATE_STR(b) (b ? ENABLED_STR : DISABLED_STR)
+
+// clang-format off
+UX_STEP_CB(
+    ux_settings_flow_blind_signing_step,
+#ifdef TARGET_NANOS
+    bnnn_paging,
+#else
+    bnnn,
+#endif
+    switch_settings_blind_signing(),
+    {
+#ifdef TARGET_NANOS
+      .title = "Blind signing",
+      .text =
+#else
+      "Blind signing",
+      "Transaction",
+      "blind signing",
+#endif
+      SETTING_BLIND_SIGNING_STATE
+    });
+
+UX_FLOW(ux_settings_flow,
+        &ux_settings_flow_blind_signing_step, &ux_menu_back_step, FLOW_LOOP);
+
+static void display_settings(const ux_flow_step_t* const start_step) {
+    strlcpy(SETTING_BLIND_SIGNING_STATE, BOOL_TO_STATE_STR(N_storage.dataAllowed), BUF_INCREMENT);
+
+    ux_flow_init(0, ux_settings_flow, start_step);
+}
+
+static void toggle_setting(volatile bool* setting, const ux_flow_step_t* ui_step) {
+    bool value = !*setting;
+    nvm_write((void*) setting, (void*) &value, sizeof(value));
+    display_settings(ui_step);
+}
+
+static void switch_settings_blind_signing(void) {
+    toggle_setting(&N_storage.dataAllowed, &ux_settings_flow_blind_signing_step);
 }
 #endif  // HAVE_BAGL

--- a/src/ui/menu_nbgl.c
+++ b/src/ui/menu_nbgl.c
@@ -20,16 +20,54 @@
 
 #include "../globals.h"
 #include "menu.h"
+#include "display.h"
 
 static const char* const infoTypes[] = {"Version", "Developer", "Copyright"};
 static const char* const infoContents[] = {APPVERSION, "Ledger", "(c) 2023 Ledger"};
 
+enum {
+    BLIND_SIGNING_TOKEN = FIRST_USER_TOKEN,
+};
+
+static nbgl_layoutSwitch_t switches[1];
+
+static void controls_call_back(int token, uint8_t index) {
+    (void) index;
+    uint8_t value;
+    switch (token) {
+        case BLIND_SIGNING_TOKEN:
+            value = (N_storage.dataAllowed ? 0 : 1);
+            nvm_write((void*) &N_storage.dataAllowed, (void*) &value, sizeof(uint8_t));
+            break;
+    }
+}
+
 static bool navigation_cb(uint8_t page, nbgl_pageContent_t* content) {
-    UNUSED(page);
-    content->type = INFOS_LIST;
-    content->infosList.nbInfos = 3;
-    content->infosList.infoTypes = (const char**) infoTypes;
-    content->infosList.infoContents = (const char**) infoContents;
+    uint8_t index = 0;
+    switch (page) {
+        case 0:
+            content->type = INFOS_LIST;
+            content->infosList.nbInfos = 3;
+            content->infosList.infoTypes = (const char**) infoTypes;
+            content->infosList.infoContents = (const char**) infoContents;
+            break;
+
+        case 1:
+            switches[index++] =
+                (nbgl_layoutSwitch_t){.initState = N_storage.dataAllowed ? ON_STATE : OFF_STATE,
+                                      .text = "Blind signing",
+                                      .subText = "Enable transaction blind\nsigning",
+                                      .token = BLIND_SIGNING_TOKEN,
+                                      .tuneId = TUNE_TAP_CASUAL};
+            content->type = SWITCHES_LIST;
+            content->switchesList.nbSwitches = index;
+            content->switchesList.switches = (nbgl_layoutSwitch_t*) switches;
+            break;
+
+        default:
+            return false;
+            break;
+    }
     return true;
 }
 
@@ -51,10 +89,18 @@ void ui_menu_main_flow_bitcoin_testnet(void) {
 }
 
 void ui_menu_about(void) {
-    nbgl_useCaseSettings("Qtum", 0, 1, false, ui_menu_main, navigation_cb, NULL);
+    nbgl_useCaseSettings("Qtum", 0, 2, false, ui_menu_main, navigation_cb, controls_call_back);
 }
 
 void ui_menu_about_testnet(void) {
-    nbgl_useCaseSettings("Qtum Test", 0, 1, false, ui_menu_main, navigation_cb, NULL);
+    nbgl_useCaseSettings("Qtum Test", 0, 2, false, ui_menu_main, navigation_cb, controls_call_back);
+}
+
+void settings_call_back(void) {
+    set_ux_flow_response(N_storage.dataAllowed);
+}
+
+void ui_menu_settings(void) {
+    nbgl_useCaseSettings("Qtum", 1, 2, false, settings_call_back, navigation_cb, controls_call_back);
 }
 #endif  // HAVE_NBGL

--- a/src/ui/menu_nbgl.c
+++ b/src/ui/menu_nbgl.c
@@ -101,6 +101,12 @@ void settings_call_back(void) {
 }
 
 void ui_menu_settings(void) {
-    nbgl_useCaseSettings("Qtum", 1, 2, false, settings_call_back, navigation_cb, controls_call_back);
+    nbgl_useCaseSettings("Qtum",
+                         1,
+                         2,
+                         false,
+                         settings_call_back,
+                         navigation_cb,
+                         controls_call_back);
 }
 #endif  // HAVE_NBGL


### PR DESCRIPTION
Add settings menu that contain one option for blind signing based on the `app-ethereum` implementation.
Blind signing need to be enabled for all contract transactions except for delegate/undelegate since they two provide info.